### PR TITLE
bash.bashrc: Change =~ to *globs* - Fixes mkshrc

### DIFF
--- a/files/etc/bash.bashrc
+++ b/files/etc/bash.bashrc
@@ -137,7 +137,7 @@ case "$-" in
 	    # addition needs to have "%w" in the "tabs" setting, ymmv for
 	    # other console emulators.
 	    #
-	    if [[ $TERM =~ xterm* ]] ; then
+	    if [[ $TERM = *xterm* ]] ; then
 		_tsl=$(echo -en '\e]2;')
 		_isl=$(echo -en '\e]1;')
 		_fsl=$(echo -en '\007')


### PR DESCRIPTION
mksh shares bash.bashrc and [[ $TERM =~ xterm* ]] causes syntax error on Leap15 and TW;
mksh: /etc/mkshrc[140]: syntax error: unexpected operator/operand '=~'

Unless this fuzzy equal plus glob has another purpose, I see no reason to use it. Shells that share this file seem to all support double globs inside dual bracket: [[ $TERM = *xterm* ]]